### PR TITLE
Feat: add self-play SuperBot training framework

### DIFF
--- a/RLBotProject/bots/__init__.py
+++ b/RLBotProject/bots/__init__.py
@@ -1,0 +1,5 @@
+"""SuperBot reinforcement learning package."""
+
+from .learning_bot import SuperBot
+
+__all__ = ["SuperBot"]

--- a/RLBotProject/bots/base_bot.py
+++ b/RLBotProject/bots/base_bot.py
@@ -1,0 +1,139 @@
+"""Rule-based baseline strategy for SuperBot.
+
+This module contains the deterministic fallback behavior used whenever the
+reinforcement learning policy is still exploring or has not yet converged.
+The goal is to provide a competent opponent which can meaningfully play the
+ball, defend, and attack so that the learning agent has a reasonable starting
+point for bootstrapping.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Tuple
+
+from rlbot.agents.base_agent import SimpleControllerState
+from rlbot.utils.game_state_util import Vector3
+
+from rlbot.agents.base_agent import BaseAgent
+
+
+MAX_SPEED = 2300.0
+BOOST_ACCELERATION = 991.666  # uu per second, used to decide when to boost.
+
+
+@dataclass
+class DriveTarget:
+    """Represents a target for the bot to drive towards."""
+
+    location: Vector3
+    desired_speed: float
+
+
+class BaseBotStrategy:
+    """Simple car control heuristics for chasing, defending and shooting.
+
+    The logic in this class is intentionally deterministic and conservative so
+    that the reinforcement learning agent can gradually improve upon it.  It
+    drives towards the ball, attempts basic clears when defending, and shoots
+    when aligned with the opponent goal.
+    """
+
+    def __init__(self, agent: BaseAgent) -> None:
+        self.agent = agent
+
+    def get_controls(self, packet) -> SimpleControllerState:
+        car = packet.game_cars[self.agent.index]
+        ball = packet.game_ball
+        car_location = Vector3(car.physics.location)
+        car_velocity = Vector3(car.physics.velocity)
+        ball_location = Vector3(ball.physics.location)
+
+        own_goal = Vector3(0, -5120 if car.team == 0 else 5120, 0)
+        opponent_goal = Vector3(0, 5120 if car.team == 0 else -5120, 0)
+
+        # Decide whether to defend or attack based on ball position.
+        defending = (ball_location.y < 0 and car.team == 0) or (
+            ball_location.y > 0 and car.team == 1
+        )
+        if defending and ball_location.dist(own_goal) < 2000:
+            target = DriveTarget(location=own_goal - (ball_location - own_goal), desired_speed=1500)
+        else:
+            target = DriveTarget(location=ball_location, desired_speed=2000)
+
+        controls = self.drive_towards(car_location, car.physics.rotation, car_velocity, target)
+
+        # If we are close to the ball and facing the opponent goal, attempt a jump shot.
+        if ball_location.dist(car_location) < 350:
+            if self.is_facing_target(car.physics.rotation, car_location, opponent_goal):
+                controls.jump = True
+                controls.boost = True
+
+        # Use boost aggressively when chasing the ball at long distances.
+        if car.boost > 0 and car_location.dist(ball_location) > 1500 and abs(controls.steer) < 0.2:
+            controls.boost = True
+
+        # Handbrake for sharp turns when the angle is large.
+        forward, _ = self.local_coordinates(target.location - car_location, car.physics.rotation)
+        if abs(forward[1]) > 800:
+            controls.handbrake = True
+
+        return controls
+
+    def drive_towards(self, car_location: Vector3, car_rotation, car_velocity: Vector3, target: DriveTarget) -> SimpleControllerState:
+        controls = SimpleControllerState()
+        relative, local = self.local_coordinates(target.location - car_location, car_rotation)
+
+        angle_to_target = local[1]
+        distance_to_target = relative.length()
+
+        controls.throttle = 1.0
+        controls.steer = self.steer_towards(angle_to_target)
+
+        current_speed = car_velocity.length()
+        if current_speed < target.desired_speed and distance_to_target > 500:
+            controls.boost = True
+
+        return controls
+
+    @staticmethod
+    def steer_towards(angle_to_target: float) -> float:
+        # Simple proportional steering.
+        steer_correction_radians = angle_to_target
+        return max(-1.0, min(1.0, steer_correction_radians * 3.0))
+
+    @staticmethod
+    def local_coordinates(target: Vector3, car_rotation) -> Tuple[Vector3, Tuple[float, float, float]]:
+        from math import cos, sin
+
+        pitch = car_rotation.pitch
+        yaw = car_rotation.yaw
+        roll = car_rotation.roll
+
+        # Build rotation matrix from Euler angles.
+        cp = cos(pitch)
+        sp = sin(pitch)
+        cy = cos(yaw)
+        sy = sin(yaw)
+        cr = cos(roll)
+        sr = sin(roll)
+
+        matrix = (
+            (cp * cy, cy * sp * sr - sy * cr, cy * sp * cr + sy * sr),
+            (cp * sy, sy * sp * sr + cy * cr, sy * sp * cr - cy * sr),
+            (-sp, cp * sr, cp * cr),
+        )
+
+        x = target.x * matrix[0][0] + target.y * matrix[0][1] + target.z * matrix[0][2]
+        y = target.x * matrix[1][0] + target.y * matrix[1][1] + target.z * matrix[1][2]
+        z = target.x * matrix[2][0] + target.y * matrix[2][1] + target.z * matrix[2][2]
+
+        return Vector3(x, y, z), (x, y, z)
+
+    @staticmethod
+    def is_facing_target(car_rotation, car_location: Vector3, target: Vector3) -> bool:
+        _, local = BaseBotStrategy.local_coordinates(target - car_location, car_rotation)
+        angle = abs(local[1])
+        return angle < 600  # Within roughly 15 degrees.
+
+
+__all__ = ["BaseBotStrategy"]

--- a/RLBotProject/bots/evaluation.py
+++ b/RLBotProject/bots/evaluation.py
@@ -1,0 +1,119 @@
+"""Evaluation utilities for periodically benchmarking the learning policy."""
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List
+
+from rlbot.setup_manager import SetupManager
+
+
+@dataclass
+class MatchStats:
+    goals_blue: int = 0
+    goals_orange: int = 0
+    touches_blue: int = 0
+    touches_orange: int = 0
+
+    def winner(self) -> str:
+        if self.goals_blue > self.goals_orange:
+            return "blue"
+        if self.goals_orange > self.goals_blue:
+            return "orange"
+        return "draw"
+
+
+@dataclass
+class EvaluationResult:
+    matches: List[MatchStats] = field(default_factory=list)
+
+    @property
+    def summary(self) -> Dict[str, float]:
+        total_blue_wins = sum(1 for m in self.matches if m.winner() == "blue")
+        total_orange_wins = sum(1 for m in self.matches if m.winner() == "orange")
+        draws = len(self.matches) - total_blue_wins - total_orange_wins
+        total_blue_goals = sum(m.goals_blue for m in self.matches)
+        total_orange_goals = sum(m.goals_orange for m in self.matches)
+        total_blue_touches = sum(m.touches_blue for m in self.matches)
+        total_orange_touches = sum(m.touches_orange for m in self.matches)
+        games = len(self.matches) or 1
+        return {
+            "blue_win_rate": total_blue_wins / games,
+            "orange_win_rate": total_orange_wins / games,
+            "draw_rate": draws / games,
+            "avg_blue_goals": total_blue_goals / games,
+            "avg_orange_goals": total_orange_goals / games,
+            "avg_blue_touches": total_blue_touches / games,
+            "avg_orange_touches": total_orange_touches / games,
+        }
+
+    def to_json(self) -> str:
+        return json.dumps(
+            {
+                "matches": [
+                    {
+                        "goals_blue": m.goals_blue,
+                        "goals_orange": m.goals_orange,
+                        "touches_blue": m.touches_blue,
+                        "touches_orange": m.touches_orange,
+                    }
+                    for m in self.matches
+                ],
+                "summary": self.summary,
+            }
+        )
+
+
+class Evaluator:
+    """Runs short best-of-N series using frozen policies."""
+
+    def __init__(self, config_path: Path, log_path: Path) -> None:
+        self.config_path = config_path
+        self.log_path = log_path
+        self.log_path.parent.mkdir(parents=True, exist_ok=True)
+
+    def run_best_of(self, games: int = 3) -> EvaluationResult:
+        manager = SetupManager()
+        manager.load_config(self.config_path)
+        manager.connect_and_start()
+        manager.launch_rocket_league_if_needed()
+
+        result = EvaluationResult()
+        try:
+            for _ in range(games):
+                manager.start_match()
+                stats = self._play_single_game(manager)
+                result.matches.append(stats)
+        finally:
+            manager.shut_down()
+
+        with open(self.log_path, "a", encoding="utf-8") as handle:
+            handle.write(result.to_json() + "\n")
+        return result
+
+    def _play_single_game(self, manager: SetupManager) -> MatchStats:
+        stats = MatchStats()
+        last_touch_time = -1.0
+        while True:
+            packet = manager.game_interface.update_live_data_packet()
+            if packet is None:
+                time.sleep(0.1)
+                continue
+            stats.goals_blue = packet.teams[0].score
+            stats.goals_orange = packet.teams[1].score
+            touch = packet.game_ball.latest_touch
+            if touch and touch.time_seconds > last_touch_time:
+                last_touch_time = touch.time_seconds
+                if touch.team == 0:
+                    stats.touches_blue += 1
+                elif touch.team == 1:
+                    stats.touches_orange += 1
+            if packet.game_info.is_match_ended:
+                break
+            time.sleep(0.1)
+        return stats
+
+
+__all__ = ["Evaluator", "EvaluationResult", "MatchStats"]

--- a/RLBotProject/bots/learning_bot.py
+++ b/RLBotProject/bots/learning_bot.py
@@ -1,0 +1,172 @@
+"""RLBot agent that combines rule-based heuristics with reinforcement learning."""
+from __future__ import annotations
+
+import math
+import time
+from pathlib import Path
+from typing import List, Optional
+
+import numpy as np
+import torch
+from rlbot.agents.base_agent import BaseAgent, SimpleControllerState
+from rlbot.utils.structures.game_data_struct import GameTickPacket
+
+from .base_bot import BaseBotStrategy
+from .policy_network import PolicyNetwork
+from .replay_buffer import ReplayBuffer, Transition
+from .reward_functions import RewardContext, compute_reward
+from .state_representation import STATE_DIMENSION, build_state
+from .trainer import ExperienceLogger, Trainer, TrainerConfig
+
+ACTION_TEMPLATES: List[dict] = [
+    {"throttle": 1.0, "steer": 0.0, "boost": False, "jump": False, "handbrake": False},
+    {"throttle": 1.0, "steer": 0.5, "boost": False, "jump": False, "handbrake": False},
+    {"throttle": 1.0, "steer": -0.5, "boost": False, "jump": False, "handbrake": False},
+    {"throttle": 1.0, "steer": 1.0, "boost": False, "jump": False, "handbrake": True},
+    {"throttle": 1.0, "steer": -1.0, "boost": False, "jump": False, "handbrake": True},
+    {"throttle": 0.5, "steer": 0.0, "boost": False, "jump": False, "handbrake": False},
+    {"throttle": 0.2, "steer": 0.0, "boost": False, "jump": False, "handbrake": False},
+    {"throttle": 1.0, "steer": 0.0, "boost": True, "jump": False, "handbrake": False},
+    {"throttle": 1.0, "steer": 0.5, "boost": True, "jump": False, "handbrake": False},
+    {"throttle": 1.0, "steer": -0.5, "boost": True, "jump": False, "handbrake": False},
+    {"throttle": 0.8, "steer": 0.0, "boost": False, "jump": True, "handbrake": False},
+    {"throttle": 1.0, "steer": 0.0, "boost": True, "jump": True, "handbrake": False},
+    {"throttle": 0.0, "steer": 0.0, "boost": False, "jump": True, "handbrake": False},
+    {"throttle": 0.8, "steer": 0.0, "boost": False, "jump": False, "handbrake": True},
+    {"throttle": 0.6, "steer": 0.7, "boost": False, "jump": False, "handbrake": False},
+    {"throttle": 0.6, "steer": -0.7, "boost": False, "jump": False, "handbrake": False},
+]
+
+ACTION_SPACE_SIZE = len(ACTION_TEMPLATES)
+
+
+class SuperBot(BaseAgent):
+    """Self-play reinforcement learning agent."""
+
+    def initialize_agent(self) -> None:
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self.base_strategy = BaseBotStrategy(self)
+        self.replay_buffer = ReplayBuffer(capacity=50000)
+        self.reward_context = RewardContext()
+        self.previous_state: Optional[np.ndarray] = None
+        self.previous_action: Optional[int] = None
+        self.match_guid: Optional[str] = None
+        self.epsilon = 1.0
+        self.min_epsilon = 0.05
+        self.epsilon_decay = 5e-5
+        self.last_training_time = time.time()
+
+        self.weights_path = (Path(__file__).resolve().parent / "checkpoints/policy.pt").resolve()
+        self.replay_log_dir = (Path(__file__).resolve().parent / "replays").resolve()
+
+        self.policy = PolicyNetwork(STATE_DIMENSION, ACTION_SPACE_SIZE)
+        self.target = PolicyNetwork(STATE_DIMENSION, ACTION_SPACE_SIZE)
+        config = TrainerConfig(device=str(self.device), checkpoint_path=self.weights_path)
+        self.experience_logger = ExperienceLogger(self.replay_log_dir, self.name)
+        self.trainer = Trainer(self.policy, self.target, self.replay_buffer, config, self.experience_logger)
+        self.trainer.load_checkpoint()
+
+        self.set_game_state(None)
+
+    def get_output(self, packet: GameTickPacket) -> SimpleControllerState:
+        if self.match_guid is None:
+            guid = packet.game_info.match_guid
+            if not guid:
+                guid = f"match-{int(time.time())}"
+            self.match_guid = guid
+            self.reward_context.last_blue_score = packet.teams[0].score
+            self.reward_context.last_orange_score = packet.teams[1].score
+            self.reward_context.last_boost = packet.game_cars[self.index].boost
+            self.reward_context.last_time = packet.game_info.seconds_elapsed
+
+        state_vector = build_state(self, packet).values
+        controller_state: SimpleControllerState
+
+        use_policy = len(self.replay_buffer) >= self.trainer.config.min_buffer_size / 2
+        action_index: int
+
+        if use_policy:
+            state_tensor = torch.tensor(state_vector, dtype=torch.float32, device=self.device)
+            action_index = self.policy.predict_action(state_tensor, self.epsilon)
+            controller_state = self._action_to_controller(action_index)
+            self.epsilon = max(self.min_epsilon, self.epsilon - self.epsilon_decay)
+        else:
+            controller_state = self.base_strategy.get_controls(packet)
+            action_index = self._approximate_action(controller_state)
+
+        if self.previous_state is not None and self.previous_action is not None:
+            reward, done = compute_reward(self, packet, self.reward_context)
+            transition = Transition(
+                state=self.previous_state,
+                action=self.previous_action,
+                reward=reward,
+                next_state=state_vector,
+                done=done,
+            )
+            self.replay_buffer.add(
+                transition.state,
+                transition.action,
+                transition.reward,
+                transition.next_state,
+                transition.done,
+            )
+            self.trainer.log_transition(self.match_guid, transition)
+            loss = self.trainer.maybe_train()
+            if loss is not None and time.time() - self.last_training_time > 1.0:
+                self.logger.info(f"Training loss: {loss:.4f}")
+                self.last_training_time = time.time()
+            if done:
+                self._reset_episode(packet)
+        else:
+            self.reward_context.last_blue_score = packet.teams[0].score
+            self.reward_context.last_orange_score = packet.teams[1].score
+            self.reward_context.last_boost = packet.game_cars[self.index].boost
+            self.reward_context.last_time = packet.game_info.seconds_elapsed
+
+        self.previous_state = state_vector
+        self.previous_action = action_index
+
+        return controller_state
+
+    def _action_to_controller(self, action_index: int) -> SimpleControllerState:
+        template = ACTION_TEMPLATES[action_index]
+        controller = SimpleControllerState()
+        controller.throttle = float(np.clip(template["throttle"], 0.0, 1.0))
+        controller.steer = float(np.clip(template["steer"], -1.0, 1.0))
+        controller.boost = bool(template["boost"])
+        controller.jump = bool(template["jump"])
+        controller.handbrake = bool(template["handbrake"])
+        controller.pitch = 0.0
+        controller.yaw = controller.steer
+        controller.roll = 0.0
+        return controller
+
+    def _approximate_action(self, controller: SimpleControllerState) -> int:
+        best_index = 0
+        best_distance = math.inf
+        for idx, template in enumerate(ACTION_TEMPLATES):
+            distance = 0.0
+            distance += (template["throttle"] - float(controller.throttle)) ** 2
+            distance += (template["steer"] - float(controller.steer)) ** 2
+            distance += (float(template["boost"]) - float(controller.boost)) ** 2
+            distance += (float(template["jump"]) - float(controller.jump)) ** 2
+            distance += (float(template["handbrake"]) - float(controller.handbrake)) ** 2
+            if distance < best_distance:
+                best_distance = distance
+                best_index = idx
+        return best_index
+
+    def _reset_episode(self, packet: GameTickPacket) -> None:
+        self.previous_state = None
+        self.previous_action = None
+        self.reward_context = RewardContext(
+            last_blue_score=packet.teams[0].score,
+            last_orange_score=packet.teams[1].score,
+            last_boost=packet.game_cars[self.index].boost,
+            last_time=packet.game_info.seconds_elapsed,
+        )
+        self.match_guid = packet.game_info.match_guid or self.match_guid
+        self.trainer.save_checkpoint()
+
+
+__all__ = ["SuperBot", "ACTION_SPACE_SIZE"]

--- a/RLBotProject/bots/policy_network.py
+++ b/RLBotProject/bots/policy_network.py
@@ -1,0 +1,77 @@
+"""PyTorch policy network used for DQN-style learning."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Tuple
+
+import torch
+from torch import Tensor, nn
+
+def _build_mlp(input_dim: int, hidden_sizes: Iterable[int], output_dim: int) -> nn.Sequential:
+    layers = []
+    last_dim = input_dim
+    for hidden in hidden_sizes:
+        layers.append(nn.Linear(last_dim, hidden))
+        layers.append(nn.ReLU())
+        last_dim = hidden
+    layers.append(nn.Linear(last_dim, output_dim))
+    return nn.Sequential(*layers)
+
+
+class PolicyNetwork(nn.Module):
+    """Fully connected neural network that outputs Q-values for discrete actions."""
+
+    def __init__(self, input_dim: int, action_dim: int, hidden_sizes: Tuple[int, ...] = (256, 256)) -> None:
+        super().__init__()
+        self.model = _build_mlp(input_dim, hidden_sizes, action_dim)
+        self.action_dim = action_dim
+
+    def forward(self, inputs: Tensor) -> Tensor:  # pragma: no cover - simple wrapper
+        return self.model(inputs)
+
+    def predict_action(self, state: Tensor, epsilon: float) -> int:
+        if torch.rand(1).item() < epsilon:
+            return int(torch.randint(0, self.action_dim, (1,)).item())
+        with torch.no_grad():
+            q_values = self.forward(state.unsqueeze(0))
+        return int(torch.argmax(q_values, dim=1).item())
+
+    def train_step(
+        self,
+        optimizer: torch.optim.Optimizer,
+        criterion: nn.Module,
+        batch_states: Tensor,
+        batch_actions: Tensor,
+        batch_targets: Tensor,
+    ) -> float:
+        optimizer.zero_grad()
+        predictions = self.forward(batch_states).gather(1, batch_actions.unsqueeze(1)).squeeze(1)
+        loss = criterion(predictions, batch_targets)
+        loss.backward()
+        nn.utils.clip_grad_norm_(self.parameters(), max_norm=5.0)
+        optimizer.step()
+        return float(loss.item())
+
+    def save(self, path: Path) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        torch.save(self.state_dict(), path)
+
+    def load(self, path: Path, strict: bool = False) -> None:
+        if path.exists():
+            self.load_state_dict(torch.load(path, map_location="cpu"), strict=strict)
+
+
+@dataclass
+class PolicyIO:
+    policy_path: Path
+
+    def load_weights(self, network: PolicyNetwork) -> None:
+        if self.policy_path.exists():
+            network.load(self.policy_path)
+
+    def save_weights(self, network: PolicyNetwork) -> None:
+        network.save(self.policy_path)
+
+
+__all__ = ["PolicyNetwork", "PolicyIO"]

--- a/RLBotProject/bots/replay_buffer.py
+++ b/RLBotProject/bots/replay_buffer.py
@@ -1,0 +1,42 @@
+"""Replay buffer for storing self-play experiences."""
+from __future__ import annotations
+
+import random
+from collections import deque
+from dataclasses import dataclass
+from typing import Deque, Iterable, List, NamedTuple
+
+import numpy as np
+
+
+class Transition(NamedTuple):
+    state: np.ndarray
+    action: int
+    reward: float
+    next_state: np.ndarray
+    done: bool
+
+
+@dataclass
+class ReplayBuffer:
+    capacity: int
+
+    def __post_init__(self) -> None:
+        self._buffer: Deque[Transition] = deque(maxlen=self.capacity)
+
+    def add(self, state: np.ndarray, action: int, reward: float, next_state: np.ndarray, done: bool) -> None:
+        self._buffer.append(Transition(state, action, reward, next_state, done))
+
+    def extend(self, transitions: Iterable[Transition]) -> None:
+        for transition in transitions:
+            self._buffer.append(transition)
+
+    def sample(self, batch_size: int) -> List[Transition]:
+        batch_size = min(batch_size, len(self._buffer))
+        return random.sample(self._buffer, batch_size)
+
+    def __len__(self) -> int:  # pragma: no cover - trivial
+        return len(self._buffer)
+
+
+__all__ = ["ReplayBuffer", "Transition"]

--- a/RLBotProject/bots/reward_functions.py
+++ b/RLBotProject/bots/reward_functions.py
@@ -1,0 +1,92 @@
+"""Reward shaping utilities for SuperBot."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Tuple
+
+from rlbot.agents.base_agent import BaseAgent
+from rlbot.utils.game_state_util import Vector3
+
+GOAL_REWARD = 10.0
+GOAL_CONCEDED_PENALTY = -10.0
+BALL_VELOCITY_SCALE = 0.1
+BALL_TOUCH_REWARD = 0.05
+IDLE_PENALTY_PER_SECOND = -0.01
+BOOST_REWARD_SCALE = 0.01
+
+
+@dataclass
+class RewardContext:
+    last_blue_score: int = 0
+    last_orange_score: int = 0
+    last_boost: float = 0.0
+    last_time: float = 0.0
+    last_touch_time: float = -1.0
+
+
+def _ball_velocity_towards_goal(ball, team: int) -> float:
+    velocity = Vector3(ball.physics.velocity)
+    direction = 1.0 if team == 0 else -1.0
+    return velocity.y * direction
+
+
+def compute_reward(
+    agent: BaseAgent,
+    packet,
+    context: RewardContext,
+) -> Tuple[float, bool]:
+    """Compute the shaped reward for a single transition."""
+
+    current_time = packet.game_info.seconds_elapsed
+    delta_time = max(1e-3, current_time - context.last_time)
+    team = agent.team
+
+    reward = 0.0
+    done = False
+
+    team_score = packet.teams[team].score
+    opponent_score = packet.teams[1 - team].score
+
+    if team == 0 and team_score > context.last_blue_score:
+        reward += GOAL_REWARD
+        done = True
+    elif team == 1 and team_score > context.last_orange_score:
+        reward += GOAL_REWARD
+        done = True
+
+    if team == 0 and opponent_score > context.last_orange_score:
+        reward += GOAL_CONCEDED_PENALTY
+        done = True
+    elif team == 1 and opponent_score > context.last_blue_score:
+        reward += GOAL_CONCEDED_PENALTY
+        done = True
+
+    reward += BALL_VELOCITY_SCALE * (_ball_velocity_towards_goal(packet.game_ball, team) / 2300.0)
+
+    latest_touch = packet.game_ball.latest_touch
+    if latest_touch and latest_touch.time_seconds > context.last_touch_time:
+        if latest_touch.player_name == packet.game_cars[agent.index].name:
+            reward += BALL_TOUCH_REWARD
+            context.last_touch_time = latest_touch.time_seconds
+
+    car_velocity = Vector3(packet.game_cars[agent.index].physics.velocity)
+    if car_velocity.length() < 100.0:
+        reward += IDLE_PENALTY_PER_SECOND * delta_time
+
+    current_boost = packet.game_cars[agent.index].boost
+    boost_delta = current_boost - context.last_boost
+    if boost_delta > 0:
+        reward += BOOST_REWARD_SCALE * boost_delta
+    context.last_boost = current_boost
+
+    context.last_blue_score = packet.teams[0].score
+    context.last_orange_score = packet.teams[1].score
+    context.last_time = current_time
+
+    if packet.game_info.is_match_ended:
+        done = True
+
+    return reward, done
+
+
+__all__ = ["RewardContext", "compute_reward"]

--- a/RLBotProject/bots/state_representation.py
+++ b/RLBotProject/bots/state_representation.py
@@ -1,0 +1,99 @@
+"""State representation utilities for the SuperBot reinforcement learning agent."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+import numpy as np
+from rlbot.agents.base_agent import BaseAgent
+from rlbot.utils.game_state_util import Vector3
+
+FIELD_MAX_X = 4096.0
+FIELD_MAX_Y = 5120.0
+FIELD_MAX_Z = 2044.0
+MAX_VELOCITY = 2300.0
+MAX_ANGULAR = 5.5
+MAX_DISTANCE = float((FIELD_MAX_X**2 + FIELD_MAX_Y**2 + FIELD_MAX_Z**2) ** 0.5)
+
+
+@dataclass
+class StateVector:
+    values: np.ndarray
+
+
+def _normalize_vector(vec: Vector3) -> List[float]:
+    return [
+        vec.x / FIELD_MAX_X,
+        vec.y / FIELD_MAX_Y,
+        vec.z / FIELD_MAX_Z,
+    ]
+
+
+def _rotation_to_sin_cos(rot) -> List[float]:
+    from math import sin, cos
+
+    return [sin(rot.pitch), cos(rot.pitch), sin(rot.yaw), cos(rot.yaw), sin(rot.roll), cos(rot.roll)]
+
+
+def build_state(agent: BaseAgent, packet) -> StateVector:
+    car = packet.game_cars[agent.index]
+    opponent_index = 1 - agent.index if agent.team == 0 else 0
+    opponent = packet.game_cars[opponent_index]
+    ball = packet.game_ball
+
+    car_location = Vector3(car.physics.location)
+    car_velocity = Vector3(car.physics.velocity)
+    opponent_location = Vector3(opponent.physics.location)
+    ball_location = Vector3(ball.physics.location)
+    ball_velocity = Vector3(ball.physics.velocity)
+
+    boost_amount = car.boost / 100.0
+
+    rel_ball = ball_location - car_location
+    rel_opponent = opponent_location - car_location
+
+    dist_ball = rel_ball.length() / MAX_DISTANCE
+    opponent_goal_y = 5120.0 if agent.team == 0 else -5120.0
+    goal_location = Vector3(0.0, opponent_goal_y, 0.0)
+    dist_goal = (goal_location - car_location).length() / MAX_DISTANCE
+
+    orientation_features = _rotation_to_sin_cos(car.physics.rotation)
+
+    state_values = np.array(
+        [
+            *_normalize_vector(ball_location),
+            *(ball_velocity.x / MAX_VELOCITY, ball_velocity.y / MAX_VELOCITY, ball_velocity.z / MAX_VELOCITY),
+            *_normalize_vector(car_location),
+            *(car_velocity.x / MAX_VELOCITY, car_velocity.y / MAX_VELOCITY, car_velocity.z / MAX_VELOCITY),
+            boost_amount,
+            *orientation_features,
+            *_normalize_vector(rel_ball),
+            *_normalize_vector(rel_opponent),
+            dist_ball,
+            dist_goal,
+        ],
+        dtype=np.float32,
+    )
+
+    return StateVector(values=state_values)
+
+
+# The state vector is comprised of the following features:
+# - Ball position (3)
+# - Ball velocity (3)
+# - Car position (3)
+# - Car velocity (3)
+# - Boost amount (1)
+# - Car orientation encoded as sin/cos pairs (6)
+# - Relative ball position (3)
+# - Relative opponent position (3)
+# - Distance to ball (1)
+# - Distance to goal (1)
+STATE_DIMENSION = 27
+
+
+def get_state_dimension(agent: BaseAgent, packet) -> int:
+    return build_state(agent, packet).values.shape[0]
+
+
+__all__ = ["StateVector", "build_state", "get_state_dimension"]

--- a/RLBotProject/bots/trainer.py
+++ b/RLBotProject/bots/trainer.py
@@ -1,0 +1,190 @@
+"""DQN training utilities and replay logging."""
+from __future__ import annotations
+
+import json
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import IO, Iterable, List, Optional, Set
+
+import numpy as np
+import torch
+from torch import Tensor, nn
+
+from .policy_network import PolicyNetwork, PolicyIO
+from .replay_buffer import ReplayBuffer, Transition
+
+
+@dataclass
+class TrainerConfig:
+    gamma: float = 0.99
+    batch_size: int = 64
+    learning_rate: float = 1e-4
+    min_buffer_size: int = 500
+    target_update_interval: int = 500
+    save_interval: int = 2000
+    device: str = "cpu"
+    checkpoint_path: Path = Path("bots/checkpoints/policy.pt")
+
+
+class ExperienceLogger:
+    """Writes transitions to JSONL files for offline inspection and training."""
+
+    def __init__(self, directory: Path, agent_name: str) -> None:
+        base = Path(__file__).resolve().parent
+        self.directory = (base / directory).resolve() if not directory.is_absolute() else directory
+        self.agent_name = agent_name
+        self.directory.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.Lock()
+        self._handle: Optional[IO[str]] = None
+        self._match_id: Optional[str] = None
+
+    def _ensure_file(self, match_id: str) -> None:
+        if self._match_id == match_id and self._handle:
+            return
+        if self._handle:
+            self._handle.close()
+        timestamp = time.strftime("%Y%m%d-%H%M%S")
+        file_path = self.directory / f"{self.agent_name}_{match_id}_{timestamp}.jsonl"
+        self._handle = open(file_path, "a", encoding="utf-8")
+        self._match_id = match_id
+
+    def log(self, match_id: str, transition: Transition) -> None:
+        payload = {
+            "state": transition.state.tolist(),
+            "action": int(transition.action),
+            "reward": float(transition.reward),
+            "next_state": transition.next_state.tolist(),
+            "done": bool(transition.done),
+        }
+        with self._lock:
+            self._ensure_file(match_id)
+            assert self._handle is not None
+            self._handle.write(json.dumps(payload) + "\n")
+            self._handle.flush()
+
+    def close(self) -> None:
+        with self._lock:
+            if self._handle:
+                self._handle.close()
+                self._handle = None
+                self._match_id = None
+
+
+class Trainer:
+    """Thin wrapper around the DQN training loop."""
+
+    def __init__(
+        self,
+        policy: PolicyNetwork,
+        target: PolicyNetwork,
+        replay_buffer: ReplayBuffer,
+        config: TrainerConfig,
+        logger: Optional[ExperienceLogger] = None,
+    ) -> None:
+        self.policy = policy
+        self.target = target
+        self.replay_buffer = replay_buffer
+        base_dir = Path(__file__).resolve().parent
+        if not config.checkpoint_path.is_absolute():
+            config.checkpoint_path = (base_dir / config.checkpoint_path).resolve()
+        self.config = config
+        self.logger = logger
+        self.optimizer = torch.optim.Adam(self.policy.parameters(), lr=self.config.learning_rate)
+        self.criterion = nn.MSELoss()
+        self.device = torch.device(self.config.device)
+        self.training_steps = 0
+        self.target.load_state_dict(self.policy.state_dict())
+        self.policy.to(self.device)
+        self.target.to(self.device)
+        self.policy_io = PolicyIO(self.config.checkpoint_path)
+
+    def maybe_train(self) -> Optional[float]:
+        if len(self.replay_buffer) < max(self.config.batch_size, self.config.min_buffer_size):
+            return None
+        transitions = self.replay_buffer.sample(self.config.batch_size)
+        batch = self._prepare_batch(transitions)
+        loss = self.policy.train_step(self.optimizer, self.criterion, *batch)
+        self.training_steps += 1
+
+        if self.training_steps % self.config.target_update_interval == 0:
+            self.target.load_state_dict(self.policy.state_dict())
+        if self.training_steps % self.config.save_interval == 0:
+            self.save_checkpoint()
+        return loss
+
+    def _prepare_batch(self, transitions: List[Transition]) -> Iterable[Tensor]:
+        states = torch.tensor(np.stack([t.state for t in transitions]), dtype=torch.float32, device=self.device)
+        actions = torch.tensor([t.action for t in transitions], dtype=torch.int64, device=self.device)
+        rewards = torch.tensor([t.reward for t in transitions], dtype=torch.float32, device=self.device)
+        next_states = torch.tensor(np.stack([t.next_state for t in transitions]), dtype=torch.float32, device=self.device)
+        dones = torch.tensor([t.done for t in transitions], dtype=torch.float32, device=self.device)
+
+        with torch.no_grad():
+            next_q = self.target(next_states).max(dim=1)[0]
+            targets = rewards + self.config.gamma * next_q * (1.0 - dones)
+        return states, actions, targets
+
+    def save_checkpoint(self) -> None:
+        self.policy_io.save_weights(self.policy)
+
+    def load_checkpoint(self) -> None:
+        self.policy_io.load_weights(self.policy)
+        self.target.load_state_dict(self.policy.state_dict())
+
+    def log_transition(self, match_id: str, transition: Transition) -> None:
+        if self.logger:
+            self.logger.log(match_id, transition)
+
+
+class OfflineTrainer:
+    """Utility for reading replay logs and training offline between matches."""
+
+    def __init__(self, config: TrainerConfig, state_dim: int, action_dim: int) -> None:
+        base_dir = Path(__file__).resolve().parent
+        if not config.checkpoint_path.is_absolute():
+            config.checkpoint_path = (base_dir / config.checkpoint_path).resolve()
+        self.config = config
+        self.replay_buffer = ReplayBuffer(capacity=50000)
+        self.policy = PolicyNetwork(state_dim, action_dim)
+        self.target = PolicyNetwork(state_dim, action_dim)
+        self.trainer = Trainer(self.policy, self.target, self.replay_buffer, config)
+        self.trainer.load_checkpoint()
+        self.processed_files: Set[Path] = set()
+
+    def load_replay_logs(self, directory: Path) -> None:
+        for json_file in directory.glob("*.jsonl"):
+            if json_file in self.processed_files:
+                continue
+            with open(json_file, "r", encoding="utf-8") as handle:
+                for line in handle:
+                    record = json.loads(line)
+                    transition = Transition(
+                        state=np.array(record["state"], dtype=np.float32),
+                        action=int(record["action"]),
+                        reward=float(record["reward"]),
+                        next_state=np.array(record["next_state"], dtype=np.float32),
+                        done=bool(record["done"]),
+                    )
+                    self.replay_buffer.add(
+                        transition.state,
+                        transition.action,
+                        transition.reward,
+                        transition.next_state,
+                        transition.done,
+                    )
+            self.processed_files.add(json_file)
+
+    def train(self, iterations: int = 200) -> None:
+        for _ in range(iterations):
+            self.trainer.maybe_train()
+        self.trainer.save_checkpoint()
+
+
+__all__ = [
+    "Trainer",
+    "TrainerConfig",
+    "ExperienceLogger",
+    "OfflineTrainer",
+]

--- a/RLBotProject/rlbot.cfg
+++ b/RLBotProject/rlbot.cfg
@@ -1,0 +1,18 @@
+[RLBot Configuration]
+num_participants = 2
+
+[Match Configuration]
+game_mode = Soccar
+game_speed = 1.0
+
+[Participant Configuration]
+team = 0
+bot = True
+name = SuperBot Blue
+bot_config = super_bot.cfg
+
+[Participant Configuration]
+team = 1
+bot = True
+name = SuperBot Orange
+bot_config = super_bot.cfg

--- a/RLBotProject/run_training_match.py
+++ b/RLBotProject/run_training_match.py
@@ -1,0 +1,72 @@
+"""Entry point for running self-play training matches with SuperBot.
+
+Scaling guide:
+    * PPO / A3C: Replace the DQN ``OfflineTrainer`` with an actor-critic
+      implementation (e.g. torch.distributions for stochastic policies) and
+      collect rollouts by storing log-probabilities alongside state/action data.
+    * GPU acceleration: instantiate :class:`TrainerConfig` with
+      ``device="cuda"`` when CUDA is available to leverage PyTorch's GPU ops.
+    * Curriculum learning: modify :data:`MAX_MATCHES` to iterate through
+      increasingly complex ``rlbot.cfg`` variations (e.g. different maps or
+      mutators) by copying the configuration file before launching each match.
+    * Self-play league: maintain a directory of historic checkpoints and load a
+      random opponent weight file in ``super_bot.cfg`` before each episode to
+      prevent overfitting to the latest policy.
+"""
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+from rlbot.setup_manager import SetupManager
+
+from bots.evaluation import Evaluator
+from bots.learning_bot import ACTION_SPACE_SIZE
+from bots.state_representation import STATE_DIMENSION
+from bots.trainer import OfflineTrainer, TrainerConfig
+
+MAX_MATCHES = 50
+EVALUATION_INTERVAL = 5
+
+
+def _wait_for_match_end(manager: SetupManager) -> None:
+    while True:
+        packet = manager.game_interface.update_live_data_packet()
+        if packet and packet.game_info.is_match_ended:
+            break
+        time.sleep(1.0)
+
+
+def main() -> None:
+    project_root = Path(__file__).resolve().parent
+    config_path = project_root / "rlbot.cfg"
+    checkpoint_path = project_root / "bots/checkpoints/policy.pt"
+    replay_dir = project_root / "bots/replays"
+
+    trainer_config = TrainerConfig(checkpoint_path=checkpoint_path)
+    offline_trainer = OfflineTrainer(trainer_config, STATE_DIMENSION, ACTION_SPACE_SIZE)
+    evaluator = Evaluator(config_path, project_root / "bots/checkpoints/evaluation_log.jsonl")
+
+    manager = SetupManager()
+    manager.load_config(config_path)
+    manager.connect_and_start()
+    manager.launch_rocket_league_if_needed()
+
+    try:
+        for match_index in range(MAX_MATCHES):
+            print(f"Starting match {match_index + 1}/{MAX_MATCHES}")
+            manager.start_match()
+            _wait_for_match_end(manager)
+
+            offline_trainer.load_replay_logs(replay_dir)
+            offline_trainer.train()
+
+            if (match_index + 1) % EVALUATION_INTERVAL == 0:
+                print("Running evaluation series...")
+                evaluator.run_best_of()
+    finally:
+        manager.shut_down()
+
+
+if __name__ == "__main__":
+    main()

--- a/RLBotProject/super_bot.cfg
+++ b/RLBotProject/super_bot.cfg
@@ -1,0 +1,22 @@
+[Locations]
+python_file = bots/learning_bot.py
+name = SuperBot
+team = 0
+
+[Details]
+description = Self-play reinforcement learning Rocket League bot.
+python_class = bots.learning_bot.SuperBot
+supports_early_start = True
+requires_human = False
+minimum_python_version = 3.11
+
+[Appearance]
+loadout_generator = rlbot.loadout.simple_loadout_generator.SimpleLoadoutGenerator
+primary_color = 32
+accent_color = 2
+finish_type_primary = 0
+finish_type_secondary = 0
+
+[Bot Parameters]
+policy_weights = bots/checkpoints/policy.pt
+replay_log_dir = bots/replays


### PR DESCRIPTION
## Summary
- create an RLBot project scaffold that launches two SuperBot agents via rlbot.cfg and run_training_match.py
- implement baseline heuristics, state encoding, reward shaping, replay buffer, policy network, and DQN trainer with logging
- add offline training loop, evaluation harness, and documentation on scaling to PPO, GPU usage, curriculum, and self-play leagues

## Testing
- python -m compileall RLBotProject

------
https://chatgpt.com/codex/tasks/task_e_68de10894524832f8253312f2b3f6b5c