### PR TITLE
Feat: implement advanced mechanics and training pipeline

### DIFF
--- a/boost_pad_tracker.py
+++ b/boost_pad_tracker.py
@@ -16,10 +16,15 @@ class BoostPad:
     is_active: bool = True
     timer: float = 0.0
 
+    def time_to_spawn(self) -> float:
+        return max(self.timer, 0.0)
+
 
 @dataclass
 class BoostPadTracker:
     pads: List[BoostPad] = field(default_factory=list)
+    small_respawn: float = 10.0
+    large_respawn: float = 20.0
 
     def initialize(self, field_info: FieldInfoPacket) -> None:
         self.pads = [
@@ -32,10 +37,21 @@ class BoostPadTracker:
             pad = self.pads[index]
             info = packet.game_boosts[index]
             pad.is_active = info.is_active
-            pad.timer = info.timer
+            pad.timer = info.timer if not info.is_active else 0.0
 
     def nearest_active(self, position: Vec3, full_boost_only: bool = False) -> BoostPad:
         candidates = self.pads if not full_boost_only else [pad for pad in self.pads if pad.is_full_boost]
         active = [pad for pad in candidates if pad.is_active]
         search = active if active else candidates
         return min(search, key=lambda pad: pad.location.distance(position))
+
+    def predict_spawn(self, pad: BoostPad) -> float:
+        """Return predicted respawn time for ``pad``."""
+
+        if pad.is_active:
+            return 0.0
+        base = self.large_respawn if pad.is_full_boost else self.small_respawn
+        return max(base - pad.timer, 0.0)
+
+    def available_pads(self) -> List[BoostPad]:
+        return [pad for pad in self.pads if pad.is_active]

--- a/drive.py
+++ b/drive.py
@@ -1,14 +1,29 @@
-"""Low-level driving helpers shared across strategies and mechanics."""
+"""Low-level driving helpers shared across strategies and mechanics.
+
+The routines in :mod:`mechanics` rely on these primitives to translate high
+level navigation requests into controller inputs.  The module provides a
+compact PID implementation for steering/pitch/roll alignment as well as flip
+executors that encapsulate the multi-frame timing required for advanced moves
+such as speed flips.
+"""
 from __future__ import annotations
 
 import math
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from enum import Enum, auto
+from typing import Deque, Optional
+
+from collections import deque
 
 from rlbot.agents.base_agent import SimpleControllerState
 from rlbot.utils.structures.game_data_struct import PlayerInfo
 
-from orientation import Orientation, relative_location
+from orientation import Orientation
 from vec import Vec3
+
+
+def clamp(value: float, lower: float = -1.0, upper: float = 1.0) -> float:
+    return max(lower, min(value, upper))
 
 
 @dataclass
@@ -20,51 +35,170 @@ class DriveTarget:
     arrive_speed: float = 1500.0
 
 
-def clamp(value: float, lower: float = -1.0, upper: float = 1.0) -> float:
-    return max(lower, min(value, upper))
+@dataclass
+class PIDController:
+    """Lightweight PID controller used for rotational alignment."""
+
+    kp: float
+    ki: float
+    kd: float
+    integral_limit: float = 3.0
+    integral: float = 0.0
+    previous_error: float = 0.0
+
+    def reset(self) -> None:
+        self.integral = 0.0
+        self.previous_error = 0.0
+
+    def step(self, error: float, dt: float) -> float:
+        self.integral += error * dt
+        self.integral = clamp(self.integral, -self.integral_limit, self.integral_limit)
+        derivative = 0.0 if dt <= 0.0 else (error - self.previous_error) / dt
+        self.previous_error = error
+        return self.kp * error + self.ki * self.integral + self.kd * derivative
 
 
-def steer_toward(car: PlayerInfo, target: Vec3) -> float:
-    """Return steer value pointing the nose toward ``target``."""
+@dataclass
+class HeadingController:
+    """PID bundle for yaw/pitch/roll."""
+
+    yaw: PIDController = field(default_factory=lambda: PIDController(4.0, 0.0, 0.5))
+    pitch: PIDController = field(default_factory=lambda: PIDController(4.0, 0.0, 0.5))
+    roll: PIDController = field(default_factory=lambda: PIDController(2.5, 0.0, 0.3))
+
+    def step(self, car: PlayerInfo, target_forward: Vec3, dt: float) -> SimpleControllerState:
+        """Return inputs aligning ``car`` forward vector to ``target_forward``."""
+
+        orientation = Orientation.from_rotator(car.physics.rotation)
+        forward = orientation.forward
+        target = target_forward.normalized()
+
+        # Errors are computed in radians using the axis-angle formulation.
+        cross = forward.cross(target)
+        dot = max(min(forward.dot(target), 1.0), -1.0)
+        angle = math.atan2(cross.magnitude(), dot)
+        # Axis components projected into the local basis control yaw/pitch/roll.
+        yaw_error = math.atan2(cross.dot(orientation.up), dot)
+        pitch_error = -math.atan2(cross.dot(orientation.right), dot)
+        roll_error = math.atan2(orientation.right.dot(Vec3(0.0, 0.0, 1.0)), orientation.up.dot(Vec3(0.0, 0.0, 1.0)))
+
+        controls = SimpleControllerState()
+        controls.yaw = clamp(self.yaw.step(yaw_error, dt))
+        controls.pitch = clamp(self.pitch.step(pitch_error, dt))
+        controls.roll = clamp(self.roll.step(roll_error, dt))
+
+        # When the error is large use boost and throttle aggressively.
+        controls.throttle = clamp(2.5 * angle)
+        return controls
+
+
+def forward_speed(car: PlayerInfo) -> float:
+    orientation = Orientation.from_rotator(car.physics.rotation)
+    velocity = Vec3.from_iterable((car.physics.velocity.x, car.physics.velocity.y, car.physics.velocity.z))
+    return velocity.dot(orientation.forward)
+
+
+def drive_toward(car: PlayerInfo, target: DriveTarget, dt: float, heading: Optional[HeadingController] = None) -> SimpleControllerState:
+    """Drive toward ``target`` using PID heading control."""
 
     orientation = Orientation.from_rotator(car.physics.rotation)
-    relative = relative_location(Vec3.from_iterable((car.physics.location.x, car.physics.location.y, car.physics.location.z)), orientation, target)
-    angle = math.atan2(relative.y, relative.x)
-    return clamp(angle * 5.0)
+    to_target = target.position - Vec3.from_iterable((car.physics.location.x, car.physics.location.y, car.physics.location.z))
+    direction = to_target.normalized()
 
+    heading = heading or HeadingController()
+    controls = heading.step(car, direction, dt)
 
-def throttle_toward(car: PlayerInfo, target: Vec3, arrive_speed: float) -> float:
-    """Return throttle to approach ``target`` with ``arrive_speed``."""
+    speed_error = target.arrive_speed - forward_speed(car)
+    controls.throttle = clamp(speed_error / 500.0)
 
-    car_velocity = Vec3.from_iterable((car.physics.velocity.x, car.physics.velocity.y, car.physics.velocity.z))
-    orientation = Orientation.from_rotator(car.physics.rotation)
-    forward_speed = car_velocity.dot(orientation.forward)
-    speed_error = arrive_speed - forward_speed
-    throttle = clamp(speed_error / 500.0)
-    return throttle
-
-
-def simple_drive(car: PlayerInfo, target: DriveTarget) -> SimpleControllerState:
-    """Proportional controller driving toward ``target``."""
-
-    controls = SimpleControllerState()
-    controls.steer = steer_toward(car, target.position)
-    controls.throttle = throttle_toward(car, target.position, target.arrive_speed)
-
-    if target.boost_ok and should_use_boost(car, target):
+    alignment = orientation.forward.dot(direction)
+    if target.boost_ok and alignment > 0.95 and forward_speed(car) < target.arrive_speed - 200 and car.boost > 0:
         controls.boost = True
     else:
         controls.boost = False
 
+    # Mild steering assistance on the ground.
+    controls.steer = clamp(heading.yaw.previous_error * 2.5)
     return controls
 
 
-def should_use_boost(car: PlayerInfo, target: DriveTarget) -> bool:
-    """Boost if aligned and below desired speed."""
+class FlipType(Enum):
+    FRONT = auto()
+    DIAGONAL_LEFT = auto()
+    DIAGONAL_RIGHT = auto()
+    SPEED = auto()
 
-    orientation = Orientation.from_rotator(car.physics.rotation)
-    forward = orientation.forward
-    to_target = (target.position - Vec3.from_iterable((car.physics.location.x, car.physics.location.y, car.physics.location.z))).normalized()
-    alignment = forward.dot(to_target)
-    speed = Vec3.from_iterable((car.physics.velocity.x, car.physics.velocity.y, car.physics.velocity.z)).dot(forward)
-    return alignment > 0.9 and speed < target.arrive_speed and car.boost > 0
+
+@dataclass
+class FlipExecutor:
+    """Stateful helper encapsulating multi-frame flip execution."""
+
+    flip_type: FlipType
+    direction: Vec3 = Vec3(1.0, 0.0, 0.0)
+    release_time: float = 0.08
+    second_jump_delay: float = 0.15
+    total_time: float = 0.30
+    timer: float = 0.0
+    phase: int = 0
+
+    def reset(self) -> None:
+        self.timer = 0.0
+        self.phase = 0
+
+    def finished(self) -> bool:
+        return self.phase >= 3
+
+    def step(self, dt: float) -> SimpleControllerState:
+        controls = SimpleControllerState()
+        self.timer += dt
+
+        if self.phase == 0:
+            controls.jump = True
+            if self.timer >= self.release_time:
+                self.phase = 1
+        elif self.phase == 1:
+            controls.jump = False
+            if self.timer >= self.second_jump_delay:
+                self.phase = 2
+        elif self.phase == 2:
+            controls.jump = True
+            pitch, yaw = self._flip_axes()
+            controls.pitch = clamp(pitch)
+            controls.yaw = clamp(yaw)
+            controls.boost = False
+            if self.timer >= self.total_time:
+                self.phase = 3
+        else:
+            controls.jump = False
+        return controls
+
+    def _flip_axes(self) -> tuple[float, float]:
+        if self.flip_type == FlipType.FRONT:
+            return (-1.0, 0.0)
+        if self.flip_type == FlipType.DIAGONAL_LEFT:
+            return (-0.9, -0.35)
+        if self.flip_type == FlipType.DIAGONAL_RIGHT:
+            return (-0.9, 0.35)
+        # SPEED flip uses a stronger yaw component.
+        return (-0.8, -0.65 if self.direction.y >= 0 else 0.65)
+
+
+class SpeedFlipPlanner:
+    """Utility combining a diagonal flip with boost usage for kickoffs."""
+
+    def __init__(self, to_left: bool) -> None:
+        direction = Vec3(1.0, -1.0, 0.0) if to_left else Vec3(1.0, 1.0, 0.0)
+        self.executor = FlipExecutor(flip_type=FlipType.SPEED, direction=direction)
+        self.cached_controls: Deque[SimpleControllerState] = deque()
+
+    def step(self, dt: float, boost: bool = True) -> SimpleControllerState:
+        if self.executor.finished():
+            controls = SimpleControllerState()
+            controls.boost = boost
+            return controls
+
+        controls = self.executor.step(dt)
+        if self.executor.phase == 2:
+            controls.boost = boost
+        self.cached_controls.append(controls)
+        return controls

--- a/evaluation.py
+++ b/evaluation.py
@@ -1,11 +1,12 @@
 """Evaluation utilities for tracking SuperBot performance."""
 from __future__ import annotations
 
+import csv
 import json
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Optional
 
 from rlbot import runner
 
@@ -19,8 +20,22 @@ class MatchResult:
     goals_conceded: int = 0
     shots: int = 0
     saves: int = 0
+    games: int = 0
+    boost_efficiency_sum: float = 0.0
+    aerial_attempts: int = 0
+    aerial_successes: int = 0
+    flip_reset_attempts: int = 0
+    flip_reset_successes: int = 0
 
-    def record_game(self, score_difference: int, goals_for: int, goals_against: int, shots: int, saves: int) -> None:
+    def record_game(
+        self,
+        score_difference: int,
+        goals_for: int,
+        goals_against: int,
+        shots: int,
+        saves: int,
+        metrics: Dict[str, float],
+    ) -> None:
         if score_difference > 0:
             self.wins += 1
         elif score_difference < 0:
@@ -31,8 +46,39 @@ class MatchResult:
         self.goals_conceded += goals_against
         self.shots += shots
         self.saves += saves
+        self.games += 1
 
-    def as_dict(self) -> Dict[str, int]:
+        boost_used = float(metrics.get("boost_used", 0.0))
+        boost_collected = float(metrics.get("boost_collected", 1.0))
+        efficiency = boost_used / max(boost_collected, 1.0)
+        self.boost_efficiency_sum += efficiency
+
+        aerial_attempts = int(metrics.get("aerial_attempts", 0))
+        aerial_successes = int(metrics.get("aerial_successes", 0))
+        flip_attempts = int(metrics.get("flip_reset_attempts", 0))
+        flip_successes = int(metrics.get("flip_reset_successes", 0))
+
+        self.aerial_attempts += aerial_attempts
+        self.aerial_successes += aerial_successes
+        self.flip_reset_attempts += flip_attempts
+        self.flip_reset_successes += flip_successes
+
+    def aerial_success_rate(self) -> float:
+        if self.aerial_attempts == 0:
+            return 0.0
+        return self.aerial_successes / self.aerial_attempts
+
+    def flip_reset_success_rate(self) -> float:
+        if self.flip_reset_attempts == 0:
+            return 0.0
+        return self.flip_reset_successes / self.flip_reset_attempts
+
+    def boost_efficiency(self) -> float:
+        if self.games == 0:
+            return 0.0
+        return self.boost_efficiency_sum / self.games
+
+    def as_dict(self) -> Dict[str, float]:
         return {
             "wins": self.wins,
             "losses": self.losses,
@@ -41,6 +87,9 @@ class MatchResult:
             "goals_conceded": self.goals_conceded,
             "shots": self.shots,
             "saves": self.saves,
+            "boost_efficiency": round(self.boost_efficiency(), 3),
+            "aerial_success_rate": round(self.aerial_success_rate(), 3),
+            "flip_reset_success_rate": round(self.flip_reset_success_rate(), 3),
         }
 
 
@@ -51,24 +100,57 @@ class EvaluationHarness:
     config_path: Path
     matches: int = 5
     wait_time: float = 3.0
+    csv_path: Optional[Path] = None
     results: MatchResult = field(default_factory=MatchResult)
 
     def run(self) -> MatchResult:
-        for _ in range(self.matches):
-            print(f"Starting evaluation match using {self.config_path}")
+        for game_index in range(1, self.matches + 1):
+            print(f"Starting evaluation match {game_index}/{self.matches} using {self.config_path}")
             runner.main(["--config", str(self.config_path)])
             summary_path = self.config_path.with_name("match_summary.json")
             if summary_path.exists():
                 summary = json.loads(summary_path.read_text())
+                metrics = summary.get("metrics", {})
                 self.results.record_game(
                     score_difference=int(summary.get("score_difference", 0)),
                     goals_for=int(summary.get("goals_for", 0)),
                     goals_against=int(summary.get("goals_against", 0)),
                     shots=int(summary.get("shots", 0)),
                     saves=int(summary.get("saves", 0)),
+                    metrics=metrics,
                 )
+                self._append_csv(game_index, summary)
             time.sleep(self.wait_time)
         return self.results
+
+    def _append_csv(self, game_index: int, summary: Dict[str, float]) -> None:
+        if not self.csv_path:
+            return
+
+        metrics = summary.get("metrics", {})
+        row = {
+            "game": game_index,
+            "score_difference": summary.get("score_difference", 0),
+            "goals_for": summary.get("goals_for", 0),
+            "goals_against": summary.get("goals_against", 0),
+            "boost_efficiency": self.results.boost_efficiency(),
+            "aerial_success_rate": self.results.aerial_success_rate(),
+            "flip_reset_success_rate": self.results.flip_reset_success_rate(),
+            "aerial_attempts": metrics.get("aerial_attempts", 0),
+            "aerial_successes": metrics.get("aerial_successes", 0),
+            "flip_reset_attempts": metrics.get("flip_reset_attempts", 0),
+            "flip_reset_successes": metrics.get("flip_reset_successes", 0),
+            "boost_used": metrics.get("boost_used", 0.0),
+            "boost_collected": metrics.get("boost_collected", 0.0),
+        }
+
+        fieldnames = list(row.keys())
+        exists = self.csv_path.exists()
+        with self.csv_path.open("a", newline="") as handle:
+            writer = csv.DictWriter(handle, fieldnames=fieldnames)
+            if not exists:
+                writer.writeheader()
+            writer.writerow(row)
 
     def save(self, destination: Path) -> None:
         destination.write_text(json.dumps(self.results.as_dict(), indent=2))

--- a/mechanics.py
+++ b/mechanics.py
@@ -1,15 +1,19 @@
 """Advanced Rocket League mechanics implemented as reusable routines."""
 from __future__ import annotations
 
-import math
-from dataclasses import dataclass
-from typing import Optional
+from dataclasses import dataclass, field
+from enum import Enum, auto
+from typing import Callable, Deque, Optional
+
+from collections import deque
 
 from rlbot.agents.base_agent import SimpleControllerState
 from rlbot.utils.structures.game_data_struct import BallInfo, PlayerInfo
 
+from drive import DriveTarget, HeadingController, SpeedFlipPlanner, drive_toward
 from orientation import Orientation
 from vec import Vec3
+
 
 @dataclass
 class MechanicContext:
@@ -21,19 +25,43 @@ class MechanicContext:
 
     @property
     def car_position(self) -> Vec3:
-        return Vec3.from_iterable((self.car.physics.location.x, self.car.physics.location.y, self.car.physics.location.z))
+        return Vec3.from_iterable(
+            (
+                self.car.physics.location.x,
+                self.car.physics.location.y,
+                self.car.physics.location.z,
+            )
+        )
 
     @property
     def car_velocity(self) -> Vec3:
-        return Vec3.from_iterable((self.car.physics.velocity.x, self.car.physics.velocity.y, self.car.physics.velocity.z))
+        return Vec3.from_iterable(
+            (
+                self.car.physics.velocity.x,
+                self.car.physics.velocity.y,
+                self.car.physics.velocity.z,
+            )
+        )
 
     @property
     def ball_position(self) -> Vec3:
-        return Vec3.from_iterable((self.ball.physics.location.x, self.ball.physics.location.y, self.ball.physics.location.z))
+        return Vec3.from_iterable(
+            (
+                self.ball.physics.location.x,
+                self.ball.physics.location.y,
+                self.ball.physics.location.z,
+            )
+        )
 
     @property
     def ball_velocity(self) -> Vec3:
-        return Vec3.from_iterable((self.ball.physics.velocity.x, self.ball.physics.velocity.y, self.ball.physics.velocity.z))
+        return Vec3.from_iterable(
+            (
+                self.ball.physics.velocity.x,
+                self.ball.physics.velocity.y,
+                self.ball.physics.velocity.z,
+            )
+        )
 
 
 @dataclass
@@ -43,158 +71,420 @@ class MechanicPlan:
     controls: SimpleControllerState
     description: str
     active: bool = True
+    routine: Optional[MechanicRoutine] = None
 
 
-def _orientation(player: PlayerInfo) -> Orientation:
-    return Orientation.from_rotator(player.physics.rotation)
+class MechanicRoutine:
+    """Base class for reusable mechanic planners."""
+
+    description: str = ""
+
+    def step(self, context: MechanicContext) -> MechanicPlan:  # pragma: no cover - interface definition
+        raise NotImplementedError
+
+    def is_finished(self) -> bool:
+        return False
 
 
 # ----------------------------------------------------------------------------
-# Core mechanics
+# Ground driving
 # ----------------------------------------------------------------------------
 
 
-def flip_reset(context: MechanicContext) -> Optional[MechanicPlan]:
-    """Attempt a flip reset when the ball is above the car and within range."""
+@dataclass
+class GroundDriveRoutine(MechanicRoutine):
+    """Drive towards a target point using PID heading control."""
 
-    car_pos = context.car_position
-    ball_pos = context.ball_position
-    if ball_pos.z < 600 or context.car.boost < 40:
-        return None
+    target: Vec3
+    arrive_speed: float = 1800.0
+    boost_ok: bool = True
+    heading: HeadingController = field(default_factory=HeadingController)
 
-    to_ball = ball_pos - car_pos
-    if to_ball.magnitude() > 1200:
-        return None
+    def step(self, context: MechanicContext) -> MechanicPlan:
+        controls = drive_toward(
+            context.car,
+            DriveTarget(position=self.target, boost_ok=self.boost_ok, arrive_speed=self.arrive_speed),
+            context.dt,
+            heading=self.heading,
+        )
+        finished = context.car_position.distance(self.target) < 200.0
+        return MechanicPlan(controls=controls, description="Ground drive", active=not finished)
 
-    controls = SimpleControllerState()
-    controls.jump = True
-    controls.boost = True
-    orientation = _orientation(context.car)
-    pitch_target = orientation.forward.dot(to_ball.normalized())
-    controls.pitch = -pitch_target
-    controls.yaw = 0.0
-    controls.roll = 0.0
-
-    # When close enough, release boost and attempt dodge into the ball for reset.
-    if to_ball.magnitude() < 250:
-        controls.jump = True
-        controls.pitch = 0.0
-        controls.roll = 0.0
-    return MechanicPlan(controls=controls, description="Flip reset attempt")
+    def is_finished(self) -> bool:
+        return False
 
 
-def ceiling_shot(context: MechanicContext) -> Optional[MechanicPlan]:
-    """Drive up the wall and jump off the ceiling for a fast shot."""
-
-    car_pos = context.car_position
-    if car_pos.z < 1700 or abs(car_pos.x) < 1500:
-        return None
-
-    controls = SimpleControllerState()
-    controls.throttle = 1.0
-    controls.steer = 0.0
-    controls.boost = context.car.boost > 20
-    if car_pos.z > 1900:
-        controls.jump = True
-        controls.pitch = -1.0
-        controls.boost = False
-    return MechanicPlan(controls=controls, description="Ceiling shot setup")
+# ----------------------------------------------------------------------------
+# Flip resets
+# ----------------------------------------------------------------------------
 
 
-def wave_dash(context: MechanicContext) -> Optional[MechanicPlan]:
-    """Perform a diagonal dodge on landing to maintain speed."""
-
-    if context.car.physics.location.z > 150:
-        return None
-
-    if context.car.physics.velocity.z > -200:
-        return None
-
-    controls = SimpleControllerState()
-    controls.jump = False
-    controls.pitch = 0.0
-    controls.yaw = 0.0
-    controls.roll = 0.0
-    if context.car.has_wheel_contact:
-        controls.jump = True
-        controls.pitch = -0.3
-        controls.yaw = 0.7
-    return MechanicPlan(controls=controls, description="Wave dash recovery")
+class FlipResetPhase(Enum):
+    APPROACH = auto()
+    STALL = auto()
+    FINISH = auto()
 
 
-def ground_dribble(context: MechanicContext) -> Optional[MechanicPlan]:
-    """Stabilize the ball on the car roof and prepare for a flick."""
+@dataclass
+class FlipResetRoutine(MechanicRoutine):
+    """Detects and performs flip resets when approaching the ball underside."""
 
-    car_pos = context.car_position
-    ball_pos = context.ball_position
-    if ball_pos.z > 150 or (ball_pos - car_pos).magnitude() > 300:
-        return None
+    alignment_threshold: float = 0.75
+    close_distance: float = 120.0
+    phase: FlipResetPhase = FlipResetPhase.APPROACH
+    stall_time: float = 0.0
 
-    controls = SimpleControllerState()
-    controls.throttle = 0.6
-    controls.steer = 0.0
-    controls.boost = False
-    return MechanicPlan(controls=controls, description="Ground dribble carry")
+    def step(self, context: MechanicContext) -> MechanicPlan:
+        controls = SimpleControllerState()
+        orientation = Orientation.from_rotator(context.car.physics.rotation)
+        to_ball = context.ball_position - context.car_position
+        distance = to_ball.magnitude()
+        target_direction = to_ball.normalized()
 
+        if context.car.has_wheel_contact:
+            controls.jump = True
+            return MechanicPlan(controls=controls, description="Flip reset takeoff")
 
-def shadow_defense(context: MechanicContext, own_goal: Vec3) -> MechanicPlan:
-    """Position between the ball and own goal with reduced speed."""
+        alignment = orientation.forward.dot(target_direction)
+        if self.phase == FlipResetPhase.APPROACH:
+            controls.boost = context.car.boost > 0
+            controls.pitch = -target_direction.z
+            controls.yaw = target_direction.y
+            controls.roll = 0.0
+            if alignment > self.alignment_threshold and distance < 300.0:
+                self.phase = FlipResetPhase.STALL
+        elif self.phase == FlipResetPhase.STALL:
+            controls.boost = False
+            controls.jump = False
+            controls.pitch = -0.3
+            controls.roll = 0.0
+            controls.yaw = 0.0
+            self.stall_time += context.dt
+            if distance < self.close_distance or self.stall_time > 0.25:
+                controls.jump = True
+                controls.pitch = -0.9
+                self.phase = FlipResetPhase.FINISH
+        else:
+            controls.jump = False
+            controls.pitch = -0.2
+            controls.boost = False
 
-    ball_pos = context.ball_position
-    to_goal = (own_goal - ball_pos).normalized()
-    target = ball_pos + to_goal * 1400
+        active = distance > 80.0
+        return MechanicPlan(controls=controls, description="Flip reset", active=active)
 
-    controls = SimpleControllerState()
-    controls.throttle = 0.5
-    controls.steer = 0.0
-
-    orientation = _orientation(context.car)
-    local_target = (target - context.car_position).dot(orientation.forward)
-    controls.steer = math.atan2((target - context.car_position).y, (target - context.car_position).x) * 5.0
-    controls.steer = max(-1.0, min(1.0, controls.steer))
-
-    if abs(local_target) < 400:
-        controls.handbrake = True
-    return MechanicPlan(controls=controls, description="Shadow defense positioning")
-
-
-def fake_challenge(context: MechanicContext) -> MechanicPlan:
-    """Charge the ball briefly then retreat to bait a shot."""
-
-    controls = SimpleControllerState()
-    controls.throttle = 1.0
-    controls.steer = 0.0
-    controls.boost = False
-    if context.ball.physics.location.z < 200:
-        controls.handbrake = True
-        controls.throttle = -0.5
-    return MechanicPlan(controls=controls, description="Fake challenge")
-
-
-def demo_run(context: MechanicContext, target: PlayerInfo) -> MechanicPlan:
-    """Hunt for a demolition when the opponent is vulnerable."""
-
-    controls = SimpleControllerState()
-    controls.throttle = 1.0
-    controls.boost = context.car.boost > 20
-    target_pos = Vec3.from_iterable((target.physics.location.x, target.physics.location.y, target.physics.location.z))
-    direction = (target_pos - context.car_position).normalized()
-    orientation = _orientation(context.car)
-    controls.steer = max(-1.0, min(1.0, orientation.right.dot(direction)))
-    return MechanicPlan(controls=controls, description="Demo chase")
+    def is_finished(self) -> bool:
+        return self.phase == FlipResetPhase.FINISH
 
 
-def psycho_shot(context: MechanicContext) -> Optional[MechanicPlan]:
-    """Attempt a psycho redirect from the backboard."""
+# ----------------------------------------------------------------------------
+# Ceiling shots
+# ----------------------------------------------------------------------------
 
-    ball_pos = context.ball_position
-    if ball_pos.z < 1200 or abs(ball_pos.y) < 3500:
-        return None
 
-    controls = SimpleControllerState()
-    controls.boost = context.car.boost > 30
-    controls.pitch = -0.5
-    controls.roll = 0.3
-    controls.yaw = 0.0
-    controls.jump = context.car.physics.location.z < 300
-    return MechanicPlan(controls=controls, description="Psycho read attempt")
+class CeilingShotPhase(Enum):
+    DRIVE_UP = auto()
+    CEILING = auto()
+    DODGE = auto()
+    COMPLETE = auto()
+
+
+@dataclass
+class CeilingShotRoutine(MechanicRoutine):
+    """Drive the ball up the wall, stick to the ceiling, and dodge midair."""
+
+    target_wall: Optional[Vec3] = None
+    phase: CeilingShotPhase = CeilingShotPhase.DRIVE_UP
+    timer: float = 0.0
+
+    def step(self, context: MechanicContext) -> MechanicPlan:
+        controls = SimpleControllerState()
+        car_pos = context.car_position
+        orientation = Orientation.from_rotator(context.car.physics.rotation)
+
+        if self.phase == CeilingShotPhase.DRIVE_UP:
+            target = self.target_wall or Vec3(car_pos.x * 1.2, car_pos.y * 1.2, 1900.0)
+            drive = GroundDriveRoutine(target=target, arrive_speed=2100.0)
+            plan = drive.step(context)
+            controls = plan.controls
+            controls.boost = context.car.boost > 0
+            if car_pos.z > 1750.0:
+                self.phase = CeilingShotPhase.CEILING
+                self.timer = 0.0
+        elif self.phase == CeilingShotPhase.CEILING:
+            controls.throttle = 0.0
+            controls.boost = False
+            controls.jump = True
+            controls.pitch = -0.8
+            self.timer += context.dt
+            if self.timer > 0.15:
+                self.phase = CeilingShotPhase.DODGE
+        elif self.phase == CeilingShotPhase.DODGE:
+            controls.jump = True
+            controls.pitch = -0.9
+            controls.yaw = 0.0
+            controls.roll = 0.0
+            if orientation.forward.z < -0.5:
+                self.phase = CeilingShotPhase.COMPLETE
+        else:
+            controls.boost = True
+            controls.pitch = -0.6
+            controls.jump = False
+
+        return MechanicPlan(controls=controls, description="Ceiling shot", active=self.phase != CeilingShotPhase.COMPLETE)
+
+    def is_finished(self) -> bool:
+        return self.phase == CeilingShotPhase.COMPLETE
+
+
+# ----------------------------------------------------------------------------
+# Wave dash
+# ----------------------------------------------------------------------------
+
+
+@dataclass
+class WaveDashRoutine(MechanicRoutine):
+    """Execute a wave dash by cancelling a flip during landing."""
+
+    jumped: bool = False
+    timer: float = 0.0
+    complete: bool = False
+
+    def step(self, context: MechanicContext) -> MechanicPlan:
+        controls = SimpleControllerState()
+        self.timer += context.dt
+
+        if not self.jumped and context.car.has_wheel_contact:
+            controls.jump = True
+            self.jumped = True
+            self.timer = 0.0
+            description = "Wave dash takeoff"
+        elif self.jumped and not context.car.has_wheel_contact:
+            controls.jump = False
+            controls.pitch = -0.3
+            controls.roll = 0.0
+            controls.yaw = 0.0
+            description = "Wave dash mid-air"
+            if context.car_velocity.z < -300 and context.car_position.z < 120.0 and self.timer > 0.12:
+                controls.jump = True
+                controls.pitch = -0.6
+                controls.yaw = 0.4
+                self.complete = True
+                description = "Wave dash landing"
+        else:
+            description = "Wave dash recovery"
+
+        return MechanicPlan(controls=controls, description=description, active=not self.complete)
+
+    def is_finished(self) -> bool:
+        return self.complete
+
+
+# ----------------------------------------------------------------------------
+# Dribbling
+# ----------------------------------------------------------------------------
+
+
+class DribblePhase(Enum):
+    CARRY = auto()
+    ADJUST = auto()
+    FLICK = auto()
+
+
+@dataclass
+class DribbleRoutine(MechanicRoutine):
+    """Maintain ball control on the roof and flick when challenged."""
+
+    target: Optional[Vec3] = None
+    phase: DribblePhase = DribblePhase.CARRY
+    challenge_detector: Callable[[MechanicContext], bool] = lambda ctx: False
+
+    def step(self, context: MechanicContext) -> MechanicPlan:
+        controls = SimpleControllerState()
+        car_pos = context.car_position
+        ball_pos = context.ball_position
+        offset = ball_pos - car_pos
+
+        if offset.z > 350.0:
+            controls.jump = False
+            controls.throttle = 1.0
+            controls.boost = context.car.boost > 20
+            return MechanicPlan(controls=controls, description="Dribble chase", active=True)
+
+        if self.phase == DribblePhase.CARRY:
+            target = self.target or ball_pos + Vec3(0.0, 0.0, 0.0)
+            drive = GroundDriveRoutine(target=target, arrive_speed=1200.0)
+            controls = drive.step(context).controls
+            controls.boost = False
+            controls.jump = False
+            if self.challenge_detector(context):
+                self.phase = DribblePhase.ADJUST
+        elif self.phase == DribblePhase.ADJUST:
+            controls.throttle = 0.5
+            controls.steer = 0.0
+            controls.pitch = -0.1
+            controls.roll = 0.0
+            if offset.z > 80.0 and abs(offset.x) < 100.0:
+                self.phase = DribblePhase.FLICK
+        else:
+            controls.jump = True
+            controls.pitch = -1.0
+            controls.yaw = 0.0
+            controls.boost = True
+
+        return MechanicPlan(controls=controls, description="Dribble", active=self.phase != DribblePhase.FLICK)
+
+    def is_finished(self) -> bool:
+        return self.phase == DribblePhase.FLICK
+
+
+# ----------------------------------------------------------------------------
+# Psycho (delayed aerial redirect)
+# ----------------------------------------------------------------------------
+
+
+class PsychoPhase(Enum):
+    ASCENT = auto()
+    TURN = auto()
+    DELAY = auto()
+    SHOT = auto()
+
+
+@dataclass
+class PsychoRoutine(MechanicRoutine):
+    """Perform an aerial with a delayed flip for a psycho shot."""
+
+    heading: HeadingController = field(default_factory=HeadingController)
+    flip_delay: float = 0.4
+    timer: float = 0.0
+    flipped: bool = False
+
+    def step(self, context: MechanicContext) -> MechanicPlan:
+        controls = SimpleControllerState()
+        to_ball = (context.ball_position - context.car_position).normalized()
+
+        if context.car.has_wheel_contact and not self.flipped:
+            controls.jump = True
+            self.timer = 0.0
+            description = "Psycho takeoff"
+        else:
+            controls = self.heading.step(context.car, to_ball, context.dt)
+            controls.boost = context.car.boost > 0
+            self.timer += context.dt
+            description = "Psycho setup"
+            if not self.flipped and self.timer > self.flip_delay:
+                controls.jump = True
+                controls.pitch = -0.9
+                controls.yaw = 0.3
+                controls.boost = False
+                self.flipped = True
+                description = "Psycho shot"
+
+        return MechanicPlan(controls=controls, description=description, active=not self.flipped)
+
+    def is_finished(self) -> bool:
+        return self.flipped
+
+
+# ----------------------------------------------------------------------------
+# Kickoffs
+# ----------------------------------------------------------------------------
+
+
+class KickoffType(Enum):
+    DIAGONAL = auto()
+    OFF_CENTER = auto()
+    STRAIGHT = auto()
+
+
+@dataclass
+class KickoffRoutine(MechanicRoutine):
+    """Execute optimized kickoff strategies based on spawn location."""
+
+    kickoff_type: KickoffType
+    planner: Optional[SpeedFlipPlanner] = None
+    boost_control: bool = True
+    cheat_distance: float = 600.0
+    cached_controls: Deque[SimpleControllerState] = field(default_factory=deque)
+
+    def step(self, context: MechanicContext) -> MechanicPlan:
+        controls = SimpleControllerState()
+        description = "Kickoff"
+
+        if self.kickoff_type == KickoffType.DIAGONAL and self.planner:
+            controls = self.planner.step(context.dt, boost=self.boost_control)
+            description = "Kickoff speed flip"
+        elif self.kickoff_type == KickoffType.DIAGONAL:
+            # Determine direction relative to centre. Negative X indicates left spawn.
+            to_left = context.car_position.x < 0.0
+            self.planner = SpeedFlipPlanner(to_left=to_left)
+            controls = self.planner.step(context.dt, boost=self.boost_control)
+            description = "Kickoff speed flip"
+        elif self.kickoff_type == KickoffType.OFF_CENTER:
+            target = context.car_position + Vec3(0.0, self.cheat_distance, 0.0)
+            drive = GroundDriveRoutine(target=target, arrive_speed=1000.0, boost_ok=False)
+            controls = drive.step(context).controls
+            description = "Kickoff cheat"
+        else:
+            target = Vec3(0.0, 0.0, 0.0)
+            drive = GroundDriveRoutine(target=target, arrive_speed=2300.0)
+            controls = drive.step(context).controls
+            controls.boost = True
+            description = "Kickoff straight"
+
+        self.cached_controls.append(controls)
+        return MechanicPlan(controls=controls, description=description, active=True)
+
+
+# Convenience factory helpers -------------------------------------------------
+
+
+def ground_drive(
+    context: MechanicContext, target: Vec3, arrive_speed: float = 1800.0, boost_ok: bool = True
+) -> MechanicPlan:
+    routine = GroundDriveRoutine(target=target, arrive_speed=arrive_speed, boost_ok=boost_ok)
+    plan = routine.step(context)
+    plan.routine = routine
+    return plan
+
+
+def flip_reset(context: MechanicContext, routine: Optional[FlipResetRoutine] = None) -> MechanicPlan:
+    routine = routine or FlipResetRoutine()
+    plan = routine.step(context)
+    plan.routine = routine
+    return plan
+
+
+def ceiling_shot(context: MechanicContext, routine: Optional[CeilingShotRoutine] = None) -> MechanicPlan:
+    routine = routine or CeilingShotRoutine()
+    plan = routine.step(context)
+    plan.routine = routine
+    return plan
+
+
+def wave_dash(context: MechanicContext, routine: Optional[WaveDashRoutine] = None) -> MechanicPlan:
+    routine = routine or WaveDashRoutine()
+    plan = routine.step(context)
+    plan.routine = routine
+    return plan
+
+
+def dribble(context: MechanicContext, routine: Optional[DribbleRoutine] = None) -> MechanicPlan:
+    routine = routine or DribbleRoutine()
+    plan = routine.step(context)
+    plan.routine = routine
+    return plan
+
+
+def psycho(context: MechanicContext, routine: Optional[PsychoRoutine] = None) -> MechanicPlan:
+    routine = routine or PsychoRoutine()
+    plan = routine.step(context)
+    plan.routine = routine
+    return plan
+
+
+def kickoff(context: MechanicContext, kickoff_type: KickoffType) -> MechanicPlan:
+    routine = KickoffRoutine(kickoff_type=kickoff_type)
+    plan = routine.step(context)
+    plan.routine = routine
+    return plan
+

--- a/training.py
+++ b/training.py
@@ -3,13 +3,23 @@ from __future__ import annotations
 
 import argparse
 import json
-from dataclasses import dataclass
+from collections import deque
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import List, Optional
+from typing import Deque, Dict, List, Optional
 
 import numpy as np
 
-from rl_components import ImitationDataset, ImitationExample, PolicyFactory, PolicyManager, ReplayBuffer, Transition, default_dqn_factory, train_imitation
+from rl_components import (
+    ImitationDataset,
+    ImitationExample,
+    PolicyFactory,
+    PolicyManager,
+    ReplayBuffer,
+    Transition,
+    default_dqn_factory,
+    train_imitation,
+)
 
 
 @dataclass
@@ -25,10 +35,75 @@ class TrainingConfig:
     checkpoint_dir: Path = Path("models")
     imitation_replays: Optional[Path] = None
     use_subprocess_env: bool = False
+    reaction_ticks: int = 8  # ~120ms at 120Hz
+    cache_ticks: tuple[int, int] = (2, 4)
+    exploration_noise: float = 0.05
+    curriculum_stages: tuple[int, int] = (150, 350)
 
 
 def linear_schedule(start: float, end: float, step: float) -> float:
     return max(end, start * step)
+
+
+@dataclass
+class ActionAugmentor:
+    """Simulate human limitations by delaying and caching inputs."""
+
+    action_dim: int
+    reaction_ticks: int
+    cache_ticks: tuple[int, int]
+    exploration_noise: float
+    queue: Deque[int] = field(default_factory=deque)
+    cache_timer: int = 0
+    cached_action: Optional[int] = None
+
+    def process(self, action: int, rng: np.random.Generator) -> int:
+        if rng.random() < self.exploration_noise:
+            action = int(rng.integers(0, self.action_dim))
+
+        self.queue.append(action)
+        if len(self.queue) > self.reaction_ticks:
+            delayed = self.queue.popleft()
+        else:
+            delayed = self.queue[0]
+
+        if self.cache_timer <= 0 or self.cached_action is None:
+            low, high = self.cache_ticks
+            self.cache_timer = int(rng.integers(low, high + 1))
+            self.cached_action = delayed
+        else:
+            self.cache_timer -= 1
+        return int(self.cached_action)
+
+
+@dataclass
+class MechanicsTutor:
+    """Collect labelled examples for advanced mechanics."""
+
+    buffer: ReplayBuffer
+    mechanic_actions: Dict[str, int]
+    success_threshold: float = 1.0
+
+    def observe(
+        self,
+        state: np.ndarray,
+        action: int,
+        reward: float,
+        next_state: np.ndarray,
+        done: bool,
+    ) -> None:
+        if action not in self.mechanic_actions.values():
+            return
+        shaped_reward = 2.0 if reward >= self.success_threshold else -0.5
+        self.buffer.push(
+            Transition(
+                state=state,
+                action=action,
+                reward=shaped_reward,
+                next_state=next_state,
+                done=done,
+            )
+        )
 
 
 def load_imitation_examples(replay_dir: Path) -> List[ImitationExample]:
@@ -47,15 +122,19 @@ def load_imitation_examples(replay_dir: Path) -> List[ImitationExample]:
 def train(config: TrainingConfig, policy_factory: PolicyFactory = default_dqn_factory()) -> None:
     from rlgym.envs import Match
     from rlgym.gym import Gym
-    from rlgym.utils.obs_builders.default import DefaultObs
     from rlgym.utils.action_parsers.default_act import DefaultAction
+    from rlgym.utils.obs_builders.default import DefaultObs
     from rlgym.utils.reward_functions.common_rewards import LiuDistancePlayerToBallReward
+    from rlgym.utils.state_setters import DefaultState
+    from rlgym.utils.state_setters.aerial_state import AerialState
+    from rlgym.utils.state_setters.dribble_state import DribbleState
 
     match = Match(
         team_size=1,
         obs_builder=DefaultObs(),
         action_parser=DefaultAction(),
         reward_function=LiuDistancePlayerToBallReward(),
+        state_setter=DribbleState(),
     )
     env = Gym(match=match, self_play=True, team_size=1)
 
@@ -65,8 +144,23 @@ def train(config: TrainingConfig, policy_factory: PolicyFactory = default_dqn_fa
 
     policy: PolicyManager = policy_factory.build(state_dim, action_dim)
     buffer = ReplayBuffer(capacity=200_000)
+    tutor = MechanicsTutor(
+        buffer=buffer,
+        mechanic_actions={
+            "flip_reset": min(action_dim - 1, 6),
+            "psycho": min(action_dim - 1, 7),
+        },
+    )
 
     epsilon = config.epsilon_start
+    rng = np.random.default_rng()
+    augmentor = ActionAugmentor(
+        action_dim=action_dim,
+        reaction_ticks=config.reaction_ticks,
+        cache_ticks=config.cache_ticks,
+        exploration_noise=config.exploration_noise,
+    )
+
     if config.imitation_replays and config.imitation_replays.exists():
         examples = load_imitation_examples(config.imitation_replays)
         if examples:
@@ -75,17 +169,35 @@ def train(config: TrainingConfig, policy_factory: PolicyFactory = default_dqn_fa
             train_imitation(policy, dataset, epochs=10)
 
     for episode in range(config.episodes):
+        # Curriculum scheduling across the three stages described in the docs.
+        if episode < config.curriculum_stages[0]:
+            match.state_setter = DribbleState()
+        elif episode < config.curriculum_stages[1]:
+            match.state_setter = AerialState()
+        else:
+            match.state_setter = DefaultState()
+
         state = np.asarray(env.reset(), dtype=np.float32)
         episode_reward = 0.0
         for step in range(config.steps_per_episode):
             action = policy.select_action(state, epsilon)
-            next_state, reward, done, _ = env.step(action)
+            delayed_action = augmentor.process(action, rng)
+            next_state, reward, done, _ = env.step(delayed_action)
             next_state = np.asarray(next_state, dtype=np.float32)
-            buffer.push(Transition(state=state, action=action, reward=float(reward), next_state=next_state, done=done))
+            buffer.push(
+                Transition(
+                    state=state,
+                    action=delayed_action,
+                    reward=float(reward),
+                    next_state=next_state,
+                    done=done,
+                )
+            )
+            tutor.observe(state, delayed_action, float(reward), next_state, done)
             state = next_state
             episode_reward += reward
             if len(buffer) > config.warmup:
-                loss = policy.optimize(buffer, batch_size=config.batch_size, gamma=config.gamma)
+                policy.optimize(buffer, batch_size=config.batch_size, gamma=config.gamma)
             if done:
                 break
 
@@ -119,3 +231,4 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
+


### PR DESCRIPTION
## Summary
- implement reusable mechanic routines for advanced plays, including flip resets, ceiling shots, wave dashes, dribbles, psychos, and kickoff logic
- add PID-based heading and flip execution helpers plus speed flip planner for mechanics to build on
- expand training pipeline with reaction delay, input caching, mechanics tutor, and curriculum scheduling while enriching evaluation metrics and boost pad tracking utilities

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68debb285e70832fbcb5af18495b33c5